### PR TITLE
Use Sphinx and Read the Docs for automatic documentation generation and hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ dist/
 **/*~
 **/*.swp
 **/._*
+
+# Documentation things
+doc/_build/
+doc/api/

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Access the package's functions with (for example)
 from waveform_collection import gather_waveforms
 ```
 and so on. Currently, documentation only exists in function docstrings. For a
-usage example, see [`example.py`](example.py).
+usage example, see [`example.py`](https://github.com/uafgeotools/waveform_collection/blob/master/example.py).
 
 Authors
 -------
 
 (_Alphabetical order by last name._)
 
-David Fee  
-Liam Toney  
+David Fee<br>
+Liam Toney<br>
 Andrew Winkelman

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 waveform_collection
 ===================
 
+[![](https://readthedocs.org/projects/uaf-waveform-collection/badge/?version=doc)](https://uaf-waveform-collection.readthedocs.io/)
+
 Package containing convenience functions to collect seismic/infrasound waveforms
 and metadata from IRIS/WATC/AVO servers or local files (miniSEED, etc.).
 
@@ -44,12 +46,15 @@ you're using conda!
 Usage
 -----
 
+Documentation is available online
+[here](https://uaf-waveform-collection.readthedocs.io/).
+
 Access the package's functions with (for example)
 ```python
 from waveform_collection import gather_waveforms
 ```
-and so on. Currently, documentation only exists in function docstrings. For a
-usage example, see [`example.py`](https://github.com/uafgeotools/waveform_collection/blob/master/example.py).
+and so on. For a usage example, see
+[`example.py`](https://github.com/uafgeotools/waveform_collection/blob/master/example.py).
 
 Authors
 -------

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,51 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../waveform_collection'))
+
+project = 'waveform_collection'
+
+html_show_copyright = False
+
+extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.napoleon',
+              'sphinx.ext.intersphinx',
+              'recommonmark',
+              'sphinx.ext.viewcode',
+              'sphinxcontrib.apidoc',
+              'sphinx.ext.mathjax'
+              ]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_theme = 'sphinx_rtd_theme'
+
+napoleon_numpy_docstring = False
+
+master_doc = 'index'
+
+autodoc_mock_imports = ['numpy',
+                        'obspy'
+                        ]
+
+apidoc_module_dir = '../waveform_collection'
+
+apidoc_output_dir = 'api'
+
+apidoc_separate_modules = True
+
+apidoc_toc_file = False
+
+# Exclude WATC-related stuff from docs for now
+apidoc_excluded_paths = ['local/cd11.py',
+                         'local/clf.py',
+                         'local/css.py',
+                         'local/smart24.py']
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'obspy': ('https://docs.obspy.org/', None)
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,8 @@ apidoc_toc_file = False
 apidoc_excluded_paths = ['local/cd11.py',
                          'local/clf.py',
                          'local/css.py',
-                         'local/smart24.py']
+                         'local/smart24.py'
+                         ]
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,14 @@
+waveform_collection
+===================
+
+Collect seismic/infrasound waveforms and metadata from IRIS/WATC/AVO servers, local miniSEED files, etc.
+
+.. toctree::
+   :caption: README
+
+   README.md
+
+.. toctree::
+   :caption: API Reference
+
+   api/waveform_collection.rst

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+sphinxcontrib-apidoc

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,7 @@
+version: 2
+
+python:
+   install:
+      - requirements: doc/requirements.txt
+      - method: setuptools
+        path: .

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ else:
 setup(
       name='waveform_collection',
       packages=find_packages(),
-      install_requires=INSTALL_REQUIRES
+      install_requires=INSTALL_REQUIRES,
       package_data={'': ['../avo_json/*.json']},
       )

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
       name='waveform_collection',
       packages=find_packages(),
       install_requires=INSTALL_REQUIRES
-      #package_data={'': ['../avo_json/*.json']},
+      package_data={'': ['../avo_json/*.json']},
       )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,15 @@
 from setuptools import setup, find_packages
+import os
+
+# https://github.com/readthedocs/readthedocs.org/issues/5512#issuecomment-475073310
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+if on_rtd:
+    INSTALL_REQUIRES = []
+else:
+    INSTALL_REQUIRES = ['obspy']
 
 setup(
       name='waveform_collection',
       packages=find_packages(),
-      install_requires=['obspy']
+      install_requires=INSTALL_REQUIRES
       )

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,12 @@ import os
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
     INSTALL_REQUIRES = []
-    INCLUDE_PACKAGE_DATA = True
 else:
     INSTALL_REQUIRES = ['obspy']
-    INCLUDE_PACKAGE_DATA = False
 
 setup(
       name='waveform_collection',
       packages=find_packages(),
-      install_requires=INSTALL_REQUIRES,
-      package_data={'': ['../avo_json/*.json']},
-      include_package_data=False#INCLUDE_PACKAGE_DATA
+      install_requires=INSTALL_REQUIRES
+      #package_data={'': ['../avo_json/*.json']},
       )

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
       packages=find_packages(),
       install_requires=INSTALL_REQUIRES,
       package_data={'': ['../avo_json/*.json']},
-      include_package_data=INCLUDE_PACKAGE_DATA
+      include_package_data=False#INCLUDE_PACKAGE_DATA
       )

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,15 @@ import os
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
     INSTALL_REQUIRES = []
+    INCLUDE_PACKAGE_DATA = True
 else:
     INSTALL_REQUIRES = ['obspy']
+    INCLUDE_PACKAGE_DATA = False
 
 setup(
       name='waveform_collection',
       packages=find_packages(),
-      install_requires=INSTALL_REQUIRES
+      install_requires=INSTALL_REQUIRES,
+      package_data={'': ['../avo_json/*.json']},
+      include_package_data=INCLUDE_PACKAGE_DATA
       )

--- a/waveform_collection/local/common.py
+++ b/waveform_collection/local/common.py
@@ -4,14 +4,15 @@ import os
 import json
 
 def check_file_exists(file):
-    '''
-    checks a that the specified file is present and readable
+    """
+    Checks that the specified file is present and readable.
 
-    Inputs:
-        file    [string]    path to file to test
-    Outputs:
-        exists  [bool]      True if file exists and is readable
-    '''
+    Args:
+        file (str): Path to file to test
+
+    Returns:
+        bool: `True` if file exists and is readable, `False` otherwise
+    """
 
     try:
         with open(file,'r'):
@@ -21,7 +22,16 @@ def check_file_exists(file):
 
 
 def check_file_extension(file, extension):
-    '''checks that the specified file has the correct extension'''
+    """
+    Checks that the specified file has the correct extension.
+
+    Args:
+        file (str): Path to file to test
+        extension (str): Extension to test for, e.g. `'.txt'`
+
+    Returns:
+        bool: `True` if `file` has extension `extension`, `False` otherwise
+    """
 
     if os.path.splitext(file)[-1].lower() == extension.lower():
         return True
@@ -30,7 +40,16 @@ def check_file_extension(file, extension):
 
 
 def load_json_file(file):
-    '''loads the specified json file (must have .json extension) using json.load()'''
+    """
+    Loads the specified JSON file (must have ``.json`` extension) using
+    :func:`json.load`.
+
+    Args:
+        file (str): Path to JSON file
+
+    Returns:
+        The contents of the JSON file
+    """
 
     file = os.path.abspath(file)
     assert check_file_exists(file), 'Error: file {} does not exists or is not readable!'.format(file)

--- a/waveform_collection/local/local.py
+++ b/waveform_collection/local/local.py
@@ -12,30 +12,37 @@ def read_local(data_dir, coord_file, network, station, location, channel,
                starttime, endtime, merge=True):
     """
     Read in waveforms from "local" 1-hour, IRIS-compliant miniSEED files, and
-    output a Stream object with station/element coordinates attached.
+    output a :class:`~obspy.core.stream.Stream` with station/element coordinates
+    attached.
 
-    NOTE 1:
-        The expected naming convention for the miniSEED files is:
-        <network>.<station>.<location>.<channel>.<year>.<julian_day>.<hour>
+    **NOTE 1**
 
-    NOTE 2:
-        This function assumes that the response has been removed from the
-        waveforms in the input miniSEED files.
+    The expected naming convention for the miniSEED files is
+
+    ``<network>.<station>.<location>.<channel>.<year>.<julian_day>.<hour>``
+
+    **NOTE 2**
+
+    This function assumes that the response has been removed from the waveforms
+    in the input miniSEED files.
 
     Args:
-        data_dir: Directory containing miniSEED files
-        coord_file: JSON file containing coordinates for local stations (full
-                    path required)
-        network: SEED network code [wildcards (*, ?) accepted]
-        station: SEED station code [wildcards (*, ?) accepted]
-        location: SEED location code [wildcards (*, ?) accepted]
-        channel: SEED channel code [wildcards (*, ?) accepted]
-        starttime: Start time for data request (UTCDateTime)
-        endtime: End time for data request (UTCDateTime)
-        merge: Toggle merging of Traces with identical IDs (default: True)
+        data_dir (str): Directory containing miniSEED files
+        coord_file (str): JSON file containing coordinates for local stations
+            (full path required)
+        network (str): SEED network code [wildcards (``*``, ``?``) accepted]
+        station (str): SEED station code [wildcards (``*``, ``?``) accepted]
+        location (str): SEED location code [wildcards (``*``, ``?``) accepted]
+        channel (str): SEED channel code [wildcards (``*``, ``?``) accepted]
+        starttime (:class:`~obspy.core.utcdatetime.UTCDateTime`): Start time for
+            data request
+        endtime (:class:`~obspy.core.utcdatetime.UTCDateTime`): End time for
+            data request
+        merge (bool): Toggle merging of :class:`~obspy.core.trace.Trace` objects
+            with identical IDs
 
     Returns:
-        st_out: Stream containing gathered waveforms
+        :class:`~obspy.core.stream.Stream` containing gathered waveforms
     """
 
     print('-----------------------------')

--- a/waveform_collection/server.py
+++ b/waveform_collection/server.py
@@ -34,42 +34,49 @@ def gather_waveforms(source, network, station, location, channel, starttime,
                      watc_username=None, watc_password=None):
     """
     Gather seismic/infrasound waveforms from IRIS or WATC FDSN, or AVO Winston,
-    and output a Stream object with station/element coordinates attached.
-    Optionally remove the sensitivity.
+    and output a :class:`~obspy.core.stream.Stream` with station/element
+    coordinates attached. Optionally remove the sensitivity.
 
-    NOTE 1:
-        Usual RTM usage is to specify a starttime/endtime that brackets the
-        estimated source origin time. Then time_buffer is used to download
-        enough extra data to account for the time required for an infrasound
-        signal to propagate to the farthest station.
+    **NOTE**
+
+    Usual RTM usage is to specify a starttime/endtime that brackets the
+    estimated source origin time. Then time_buffer is used to download enough
+    extra data to account for the time required for an infrasound signal to
+    propagate to the farthest station.
 
     Args:
-        source: Which source to gather waveforms from - options are:
-                'IRIS' <-- IRIS FDSN
-                'WATC' <-- WATC FDSN
-                'AVO'  <-- AVO Winston
-        network: SEED network code
-        station: SEED station code
-        location: SEED location code
-        channel: SEED channel code
-        starttime: Start time for data request (UTCDateTime)
-        endtime: End time for data request (UTCDateTime)
-        time_buffer: [s] Extra amount of data to download after endtime
-                     (default: 0)
-        merge: Toggle merging of Traces with identical IDs (default: True)
-        remove_response: Toggle response removal via remove_sensitivity() or a
-                         simple scalar multiplication (default: False)
-        return_failed_stations: If True, returns a list of station codes that
-                                were requested but not downloaded. This
-                                disables the standard failed station warning
-                                message (default: False)
-        watc_url: URL for WATC FDSN server (default: None)
-        watc_username: Username for WATC FDSN server (default: None)
-        watc_password: Password for WATC FDSN server (default: None)
+        source (str): Which source to gather waveforms from. Options are:
+
+            * `'IRIS'` – IRIS FDSN
+            * `'WATC'` – WATC FDSN
+            * `'AVO'` – AVO Winston
+
+        network (str): SEED network code [wildcards (``*``, ``?``) accepted]
+        station (str): SEED station code [wildcards (``*``, ``?``) accepted]
+        location (str): SEED location code [wildcards (``*``, ``?``) accepted]
+        channel (str): SEED channel code [wildcards (``*``, ``?``) accepted]
+        starttime (:class:`~obspy.core.utcdatetime.UTCDateTime`): Start time for
+            data request
+        endtime (:class:`~obspy.core.utcdatetime.UTCDateTime`): End time for
+            data request
+        time_buffer (int or float): Extra amount of data to download after
+            `endtime` [s]
+        merge (bool): Toggle merging of :class:`~obspy.core.trace.Trace` objects
+            with identical IDs
+        remove_response (bool): Toggle response removal via
+            :meth:`~obspy.core.trace.Trace.remove_sensitivity` or a simple
+            scalar multiplication
+        return_failed_stations (bool): If `True`, returns a list of station
+            codes that were requested but not downloaded. This disables the
+            standard failed station warning message
+        watc_url (str): URL for WATC FDSN server
+        watc_username (str): Username for WATC FDSN server
+        watc_password (str): Password for WATC FDSN server
+
     Returns:
-        st_out: Stream containing gathered waveforms
-        failed_stations: (Optional) List containing station codes that were
-                         requested but not downloaded
+        :class:`~obspy.core.stream.Stream` containing gathered waveforms. If
+        `return_failed_stations` is `True`, additionally returns a list
+        containing station codes that were requested but not downloaded
     """
 
     print('--------------')
@@ -242,40 +249,50 @@ def gather_waveforms_bulk(lon_0, lat_0, max_radius, starttime, endtime,
     """
     Bulk gather infrasound waveforms within a specified maximum radius of a
     specified location. Waveforms are gathered from IRIS (and optionally WATC)
-    FDSN, and AVO Winston. Outputs a Stream object with station/element
-    coordinates attached. Optionally removes the sensitivity. [Output Stream
-    has the same properties as output Stream from gather_waveforms().]
+    FDSN, and AVO Winston. Outputs a :class:`~obspy.core.stream.Stream` with
+    station/element coordinates attached. Optionally removes the sensitivity.
+    (Output :class:`~obspy.core.stream.Stream` has the same properties as output
+    :class:`~obspy.core.stream.Stream` from :func:`gather_waveforms`.)
 
-    NOTE 1:
-        WATC database will NOT be used for station search NOR data download
-        unless BOTH watc_username and watc_password are set.
+    **NOTE 1**
 
-    NOTE 2:
-        Usual RTM usage is to specify a starttime/endtime that brackets the
-        estimated source origin time. Then time_buffer is used to download
-        enough extra data to account for the time required for an infrasound
-        signal to propagate to the farthest station.
+    WATC database will NOT be used for station search NOR data download unless
+    BOTH `watc_username` and `watc_password` are set.
+
+    **NOTE 2**
+
+    Usual RTM usage is to specify a starttime/endtime that brackets the
+    estimated source origin time. Then time_buffer is used to download enough
+    extra data to account for the time required for an infrasound signal to
+    propagate to the farthest station.
 
     Args:
-        lon_0: [deg] Longitude of search center
-        lat_0: [deg] Latitude of search center
-        max_radius: [km] Maximum radius to search for stations within
-        starttime: Start time for data request (UTCDateTime)
-        endtime: End time for data request (UTCDateTime)
-        channel: SEED channel code (REQUIRED PARAMETER!)
-        network: SEED network code (default: '*')
-        station: SEED station code (default: '*')
-        location: SEED location code (default: '*')
-        time_buffer: [s] Extra amount of data to download after endtime
-                     (default: 0)
-        merge: Toggle merging of Traces with identical IDs (default: True)
-        remove_response: Toggle response removal via remove_sensitivity() or a
-                         simple scalar multiplication (default: False)
-        watc_url: URL for WATC FDSN server (default: None)
-        watc_username: Username for WATC FDSN server (default: None)
-        watc_password: Password for WATC FDSN server (default: None)
+        lon_0 (int or float): Longitude of search center [deg.]
+        lat_0 (int or float): Latitude of search center [deg.]
+        max_radius (int or float): Maximum radius to search for stations within
+            [km]
+        starttime (:class:`~obspy.core.utcdatetime.UTCDateTime`): Start time for
+            data request
+        endtime (:class:`~obspy.core.utcdatetime.UTCDateTime`): End time for
+            data request
+        channel (str): SEED channel code [wildcards (``*``, ``?``) accepted]
+            (REQUIRED PARAMETER!)
+        network (str): SEED network code [wildcards (``*``, ``?``) accepted]
+        station (str): SEED station code [wildcards (``*``, ``?``) accepted]
+        location (str): SEED location code [wildcards (``*``, ``?``) accepted]
+        time_buffer (int or float): Extra amount of data to download after
+            `endtime` [s]
+        merge (bool): Toggle merging of :class:`~obspy.core.trace.Trace` objects
+            with identical IDs
+        remove_response (bool): Toggle response removal via
+            :meth:`~obspy.core.trace.Trace.remove_sensitivity` or a simple
+            scalar multiplication
+        watc_url (str): URL for WATC FDSN server
+        watc_username (str): Username for WATC FDSN server
+        watc_password (str): Password for WATC FDSN server
+
     Returns:
-        st_out: Stream containing bulk gathered waveforms
+        :class:`~obspy.core.stream.Stream` containing bulk gathered waveforms
     """
 
     print('-------------------')
@@ -442,19 +459,22 @@ def _restricted_matching(code_type, requested_codes, avo_client,
     Find all SEED network/station/location/channel codes on AVO Winston that
     match a user-supplied query string. Optionally constrain the search to a
     particular network/station/location/channel using keyword arguments passed
-    on to `avo_client.get_availability()`.
+    on to ``avo_client.get_availability()``.
 
     Args:
-        code_type: One of 'network', 'station', 'location', or 'channel'
-        requested_codes: Comma-separated SEED code string (wildcards accepted)
-        avo_client: AVO Winston client instance
+        code_type (str): One of `'network'`, `'station'`, `'location'`, or
+            `'channel'`
+        requested_codes (str): Comma-separated SEED code string (wildcards
+            accepted)
+        avo_client (:class:`~obspy.clients.earthworm.client.Client`): AVO
+            Winston client instance
         **restriction_kwargs: Query restrictions to be passed on to
-                              `avo_client.get_availability()`
+            ``avo_client.get_availability()``
+
     Returns:
-        restricted_matching_codes: A list of SEED codes for `code_type`,
-                                   subject to the query restrictions given in
-                                   `**restriction_kwargs` AND matching the
-                                   patterns in `requested_codes`
+        list: A list of SEED codes for `code_type`, subject to the query
+        restrictions given in `**restriction_kwargs` AND matching the patterns
+        in `requested_codes`
     """
 
     # Get availability on AVO Winston subject to optional network/station/
@@ -488,16 +508,19 @@ def _restricted_matching(code_type, requested_codes, avo_client,
 
 def _matching(unique_code_list, requested_codes):
     """
-    Takes a comma-separated SEED code string (e.g., 'BD?,HDF') and returns the
-    subset of an input list of unique codes (e.g., ['BDF', 'EHZ', 'DDF']) that
-    matches the patterns in the comma-separated SEED code string.
+    Takes a comma-separated SEED code string (e.g., ``'BD?,HDF'``) and returns
+    the subset of an input list of unique codes (e.g.,
+    ``['BDF', 'EHZ', 'DDF']``) that matches the patterns in the comma-separated
+    SEED code string.
 
     Args:
-        unique_code_list: List of unique code strings
-        requested_codes: Comma-separated SEED code string (wildcards accepted)
+        unique_code_list (list): List of unique code strings
+        requested_codes (str): Comma-separated SEED code string (wildcards
+            accepted)
+
     Returns:
-        matching_codes: Subset of `unique_code_list` that matches the patterns
-                        in `requested_codes`
+        list: Subset of `unique_code_list` that matches the patterns in
+        `requested_codes`
     """
 
     matching_codes = []


### PR DESCRIPTION
This PR implements a modern documentation solution with [Sphinx](https://www.sphinx-doc.org/en/master/) for generation and [Read the Docs](https://readthedocs.org/) for hosting, similar to what was done for the RTM code in [this PR](https://github.com/uafgeotools/rtm/pull/31). The documentation is hosted at [uaf-waveform-collection.readthedocs.io](https://uaf-waveform-collection.readthedocs.io/).

The functions in `cd11.py`, `clf.py`, `css.py`, and `smart24.py` are currently not included in the documentation, since I didn't get around to editing their docstrings. They can be included in the future — once their docstrings are edited — by removing the variable `apidoc_excluded_paths` from `doc/conf.py`.

Post-merge TO-DO:

- [ ] Set up Read the Docs to work off of `master` instead of `doc`
- [ ] Edit badge link in README
- [ ] Set GitHub repo website to https://uaf-waveform-collection.readthedocs.io/
- [ ] Set up push hooks
- [ ] Update [this RTM docstring](https://uaf-rtm.readthedocs.io/en/master/api/rtm.waveform.html) to point to online documentation for `gather_waveforms()`