### PR TITLE
Use fill_value=0 for optional merge

### DIFF
--- a/waveform_collection/server.py
+++ b/waveform_collection/server.py
@@ -131,7 +131,7 @@ def gather_waveforms(source, network, station, location, channel, starttime,
                          '\'WATC\', or \'AVO\'.')
 
     if merge:
-        st_out.merge()  # Merge Traces with the same ID
+        st_out.merge(fill_value=0)  # Merge Traces with the same ID
     st_out.sort()
 
     # Check that all requested stations are present in Stream

--- a/waveform_collection/server.py
+++ b/waveform_collection/server.py
@@ -132,6 +132,7 @@ def gather_waveforms(source, network, station, location, channel, starttime,
 
     if merge:
         st_out.merge(fill_value=0)  # Merge Traces with the same ID
+        warnings.warn('Merging with "fill_value=0"', CollectionWarning)
     st_out.sort()
 
     # Check that all requested stations are present in Stream
@@ -164,6 +165,7 @@ def gather_waveforms(source, network, station, location, channel, starttime,
 
     # Add zeros to ensure all Traces have same length
     st_out.trim(starttime, endtime + time_buffer, pad=True, fill_value=0)
+    warnings.warn('Trimming with "fill_value=0"', CollectionWarning)
 
     print('Assigning coordinates...')
 


### PR DESCRIPTION
Consider the following command:
```python
from obspy import UTCDateTime
from waveform_collection import gather_waveforms

st = gather_waveforms(
    'IRIS',
    'AT',
    'SIT',
    '',
    'BHZ',
    UTCDateTime('2014-02-16T14:22:14'),
    UTCDateTime('2014-02-16T14:31:40'),
    merge=True,
)

st.plot()
```
Without merge, two traces are returned here. So we want to merge. With the current code, the output is:
![old](https://user-images.githubusercontent.com/38269494/87803295-80d92300-c80f-11ea-949b-802567a9859b.png)
With this PR, we use `fill_value=0` in the call to `Stream.merge()`, and the result is:
![new](https://user-images.githubusercontent.com/38269494/87803348-92bac600-c80f-11ea-8cbb-646f44419684.png)
This is what we'd expect.

The reason why the first plot looks weird is that `Stream.merge()` creates masked arrays by default. Later on in the code, when we trim and pad with zeros, things go haywire. This modification assures that traces are merged and filled with zeros.