### PR TITLE
Fix issue during merge when Trace dtypes are not all identical

### DIFF
--- a/waveform_collection/server.py
+++ b/waveform_collection/server.py
@@ -521,7 +521,7 @@ def _safe_merge(st, fill_value):
     Args:
         st (:class:`~obspy.core.stream.Stream`): Input Stream (modified in-place!)
         fill_value (int, float, str, or None): Passed on to
-            :meth:`~obspy.core.stream.Stream.merge()`
+            :meth:`obspy.core.stream.Stream.merge`
     """
 
     try:


### PR DESCRIPTION
If ObsPy finds that Traces with the same ID have different data types, it will raise an exception:

```
Can't merge traces with same ids but differing data types!
```

This PR implements a "safe merge" where we try to merge as usual and then if that fails, we change all data types that aren't `int32` to `int32`.

---

Note that a similar procedure could be done to avoid inconsistent sampling rate issues, such as those encountered in https://github.com/uafgeotools/rtm/issues/58#issuecomment-948053840. This could be accomplished via rounding, as in @awech's code [here](https://github.com/awech/AVO-alarms/blob/a875e4d8fffbe1c30e85421e6c36008dcdde72c3/alarm_codes/utils.py#L54) (from which this fix is based). That should be a separate PR though I think.