### PR TITLE
Attempt to round sampling rates to nearest integer in _safe_merge if merging fails

### DIFF
--- a/waveform_collection/server.py
+++ b/waveform_collection/server.py
@@ -528,8 +528,8 @@ def _safe_merge(st, fill_value):
     except Exception:  # ObsPy also raises an Exception if traces with the same ids have different sampling rates
         for tr in st:
             if tr.stats.sampling_rate != np.round(tr.stats.sampling_rate):
-                warnings.warn('Rounding off %s sample rate to the nearest integer for merge compatibility' % tr.id,
-                              CollectionWarning)
+                warnings.warn('Rounding off %s sampling rate from %f Hz to %.1f Hz for merge compatibility.' % (
+                              tr.id, tr.stats.sampling_rate, np.round(tr.stats.sampling_rate)), CollectionWarning)
                 tr.stats.sampling_rate = np.round(tr.stats.sampling_rate)
         st.merge(fill_value=fill_value)  # Try merging with rounded sampling rates
 


### PR DESCRIPTION
As discussed in #34 , we introduce an additional stream merging failsafe by rounding off sampling rates of traces with non-integer sampling rates. 

I incorporated the change in the printed statement to show both the initial and final sampling rates of the corrected traces. Note, however, that this falls under `warnings.warn` and is unaffected by the `verbose` argument, which mutes non-essential statements. I find that this sampling rate correction is important enough that the user should be made aware. 

Here's the test case from #34 :
```
from waveform_collection import gather_waveforms
from obspy import UTCDateTime
stream = gather_waveforms(source='IRIS', network='AV', station='VNHG',
                          location='', channel='*HZ', starttime=UTCDateTime(2003,1,1), 
                          endtime=UTCDateTime(2003,1,1,1), verbose=False)
```
which gives:
```
CollectionWarning: Rounding off AV.VNHG..EHZ sampling rate from 99.999992 Hz to 100.0 Hz for merge compatibility.
CollectionWarning: Rounding off AV.VNHG..EHZ sampling rate from 100.000008 Hz to 100.0 Hz for merge compatibility.
CollectionWarning: Merging with "fill_value=0"
CollectionWarning: Trimming with "fill_value=0"
```
